### PR TITLE
use look-up table for calculating emissivity

### DIFF
--- a/openet/ssebop/model.py
+++ b/openet/ssebop/model.py
@@ -818,27 +818,32 @@ class Image():
 
         """
         ndvi = Image._ndvi(toa_image)
-        Pv = ndvi.expression(
-            '((ndvi - 0.2) / 0.3) ** 2', {'ndvi': ndvi})
-        # ndviRangevalue = ndvi_image.where(
-        #     ndvi_image.gte(0.2).And(ndvi_image.lte(0.5)), ndvi_image)
-        # Pv = ndviRangevalue.expression(
-        # '(((ndviRangevalue - 0.2)/0.3)**2',{'ndviRangevalue':ndviRangevalue})
-
-        # Assuming typical Soil Emissivity of 0.97 and Veg Emissivity of 0.99
-        #   and shape Factor mean value of 0.553
-        dE = Pv.expression(
-            '(((1 - 0.97) * (1 - Pv)) * (0.55 * 0.99))', {'Pv': Pv})
-        RangeEmiss = dE.expression(
-            '((0.99 * Pv) + (0.97 * (1 - Pv)) + dE)', {'Pv': Pv, 'dE': dE})
-
-        # RangeEmiss = 0.989 # dE.expression(
-        #  '((0.99*Pv)+(0.97 *(1-Pv))+dE)',{'Pv':Pv, 'dE':dE})
-        emissivity = ndvi \
-            .where(ndvi.lt(0), 0.985) \
-            .where(ndvi.gte(0).And(ndvi.lt(0.2)), 0.977) \
-            .where(ndvi.gt(0.5), 0.99) \
-            .where(ndvi.gte(0.2).And(ndvi.lte(0.5)), RangeEmiss)
+        
+        # Create lookup table using ndvi scaled to integer
+        def ndvi_to_emiss(ndvi):
+             ndvi = ndvi / 1000
+             Pv = ((ndvi - 0.2) / 0.3)**2
+             dE = ((1 - 0.97) * (1 - Pv)) * (0.55 * 0.99)
+             RangeEmiss = (0.99 * Pv) + (0.97 * (1 - Pv)) + dE
+             return RangeEmiss
+         
+        ndvi_list = range(-1000, 1000, 1)
+        emiss_list = []
+        for i in ndvi_list:
+             if i < 0:
+                 emiss_list.append(0.985)
+             elif (i >= 0) and (i < 200):
+                 emiss_list.append(0.977)
+             elif i > 500:
+                 emiss_list.append(0.99)
+             elif (i >= 200) and (i <= 500):
+                 emiss_list.append(ndvi_to_emiss(i))
+             else:
+                 emiss_list.append(-1)
+        
+        # Apply look-up table to image
+        ndvi = ndvi.multiply(1000).round()
+        emissivity = ndvi.remap(ndvi_list, emiss_list, -1)
         emissivity = emissivity.clamp(0.977, 0.99)
 
         return emissivity.select([0], ['emissivity'])


### PR DESCRIPTION
Calculates emissivity for a list of NDVI values and applies the look-up table to an image with Image.remap, which should be faster than calculating emissivity for each pixel according to the GEE Profiler.