### PR TITLE
Test export with best effort set to false

### DIFF
--- a/openet/ssebop/image.py
+++ b/openet/ssebop/image.py
@@ -1419,11 +1419,11 @@ class Image():
         watermask_for_coarse = qa_watermask.updateMask(watermask)
 
         watermask_coarse_count = watermask_for_coarse\
-            .reduceResolution(ee.Reducer.count(), True, m_pixels)\
+            .reduceResolution(ee.Reducer.count(), False, m_pixels)\
             .reproject(self.crs, coarse_transform)\
             .updateMask(1).select([0], ['count'])
         total_pixels_count = ndvi\
-            .reduceResolution(ee.Reducer.count(), True, m_pixels)\
+            .reduceResolution(ee.Reducer.count(), False, m_pixels)\
             .reproject(self.crs, coarse_transform)\
             .updateMask(1).select([0], ['count'])
 
@@ -1438,26 +1438,26 @@ class Image():
 
         ndvi_avg_masked = ndvi\
             .updateMask(watermask)\
-            .reduceResolution(ee.Reducer.mean(), True, m_pixels)\
+            .reduceResolution(ee.Reducer.mean(), False, m_pixels)\
             .reproject(self.crs, coarse_transform)
         ndvi_avg_masked100 = ndvi\
             .updateMask(watermask)\
             .reduceResolution(ee.Reducer.mean(), True, m_pixels)\
             .reproject(self.crs, coarse_transform100)
         ndvi_avg_unmasked = ndvi\
-            .reduceResolution(ee.Reducer.mean(), True, m_pixels)\
+            .reduceResolution(ee.Reducer.mean(), False, m_pixels)\
             .reproject(self.crs, coarse_transform)\
             .updateMask(1)
         lst_avg_masked = lst\
             .updateMask(watermask)\
-            .reduceResolution(ee.Reducer.mean(), True, m_pixels)\
+            .reduceResolution(ee.Reducer.mean(), False, m_pixels)\
             .reproject(self.crs, coarse_transform)
         lst_avg_masked100 = lst\
             .updateMask(watermask)\
             .reduceResolution(ee.Reducer.mean(), True, m_pixels)\
             .reproject(self.crs, coarse_transform100)
         lst_avg_unmasked = lst\
-            .reduceResolution(ee.Reducer.mean(), True, m_pixels)\
+            .reduceResolution(ee.Reducer.mean(), False, m_pixels)\
             .reproject(self.crs, coarse_transform)\
             .updateMask(1)
 


### PR DESCRIPTION
This should return an image that is identical to having it set to True since the pixel count per cell is below the max, but we needed to check if it causes memory errors: 

- Tested, no memory errors
- Results are identical as v0.2.6

Determined to be most optimal to use 'bestEffort = True' (set to false elsewhere) for coarse_transform100 layers instead of double reduceResolution method as follows:
```
        ndvi_avg_masked100 = ndvi\
            .updateMask(watermask)\
            .reduceResolution(ee.Reducer.mean(), False, m_pixels)\
            .reproject(self.crs, coarse_transform)\
            .reduceResolution(ee.Reducer.mean(), False, m_pixels)\
            .reproject(self.crs, coarse_transform100)
```