### PR TITLE
Add support for an ET fraction grass source parameter

### DIFF
--- a/openet/ssebop/image.py
+++ b/openet/ssebop/image.py
@@ -101,6 +101,8 @@ class Image:
                                     'ECMWF/ERA5_LAND/HOURLY'}, float, optional
             Reference ET source for alfalfa to grass reference adjustment.
             Parameter must be set if et_fraction_type is 'grass'.
+            The default is currently the NLDAS hourly collection,
+            but having a default will likely be removed in a future version.
         reflectance_type : {'SR', 'TOA'}, optional
             Used to set the Tcorr NDVI thresholds (the default is 'SR').
         kwargs : dict, optional
@@ -204,12 +206,21 @@ class Image:
         self.et_fraction_type = et_fraction_type.lower()
 
         # ET fraction alfalfa to grass reference adjustment
+        # The NLDAS hourly collection will be used if a source value is not set
         if self.et_fraction_type.lower() == 'grass' and not et_fraction_grass_source:
-            raise ValueError(
-                'et_fraction_grass_source parameter must be set if et_fraction_type==\'grass\''
+            warnings.warn(
+                'NLDAS is being set as the default ET fraction grass adjustment source.  '
+                'In a future version the parameter will need to be set explicitly as: '
+                'et_fraction_grass_source="NASA/NLDAS/FORA0125_H002".',
+                FutureWarning
             )
+            et_fraction_grass_source = 'NASA/NLDAS/FORA0125_H002'
         self.et_fraction_grass_source = et_fraction_grass_source
-        # CGM - Should the supported source values be checked here instead of in model.py?
+        # if self.et_fraction_type.lower() == 'grass' and not et_fraction_grass_source:
+        #     raise ValueError(
+        #         'et_fraction_grass_source parameter must be set if et_fraction_type==\'grass\''
+        #     )
+        # # Should the supported source values be checked here instead of in model.py?
         # if et_fraction_grass_source not in et_fraction_grass_sources:
         #     raise ValueError('unsupported et_fraction_grass_source')
 

--- a/openet/ssebop/image.py
+++ b/openet/ssebop/image.py
@@ -86,7 +86,7 @@ class Image:
                        'DAYMET_MEDIAN_V2', 'CIMIS_MEDIAN_V1',
                        collection ID, or float}, optional
             Maximum air temperature source.  The default is
-            'projects/usgs-ssebop/tmax/daymet_v3_median_1980_2018'.
+            'projects/usgs-ssebop/tmax/daymet_v4_mean_1981_2010'.
         elr_flag : bool, str, optional
             If True, apply Elevation Lapse Rate (ELR) adjustment
             (the default is False).

--- a/openet/ssebop/image.py
+++ b/openet/ssebop/image.py
@@ -51,6 +51,7 @@ class Image:
             dt_min=5,
             dt_max=25,
             et_fraction_type='alfalfa',
+            et_fraction_grass_source=None,
             reflectance_type='SR',
             **kwargs,
     ):
@@ -94,10 +95,14 @@ class Image:
         dt_max : float, optional
             Maximum allowable dT [K] (the default is 25).
         et_fraction_type : {'alfalfa', 'grass'}, optional
-            ET fraction  (the default is 'alfalfa').
+            ET fraction reference type (the default is 'alfalfa').
+            If set to "grass" the et_fraction_grass_source must also be set.
+        et_fraction_grass_source : {'NASA/NLDAS/FORA0125_H002',
+                                    'ECMWF/ERA5_LAND/HOURLY'}, float, optional
+            Reference ET source for alfalfa to grass reference adjustment.
+            Parameter must be set if et_fraction_type is 'grass'.
         reflectance_type : {'SR', 'TOA'}, optional
-            Used to set the Tcorr NDVI thresholds
-            (the default is 'SR').
+            Used to set the Tcorr NDVI thresholds (the default is 'SR').
         kwargs : dict, optional
             dt_resample : {'nearest', 'bilinear'}
             tcorr_resample : {'nearest', 'bilinear'}
@@ -194,14 +199,19 @@ class Image:
                 raise ValueError(f'elr_flag "{self._elr_flag}" could not be interpreted as bool')
 
         # ET fraction type
-        # CGM - Should et_fraction_type be set as a kwarg instead?
         if et_fraction_type.lower() not in ['alfalfa', 'grass']:
             raise ValueError('et_fraction_type must "alfalfa" or "grass"')
         self.et_fraction_type = et_fraction_type.lower()
-        # if 'et_fraction_type' in kwargs.keys():
-        #     self.et_fraction_type = kwargs['et_fraction_type'].lower()
-        # else:
-        #     self.et_fraction_type = 'alfalfa'
+
+        # ET fraction alfalfa to grass reference adjustment
+        if self.et_fraction_type.lower() == 'grass' and not et_fraction_grass_source:
+            raise ValueError(
+                'et_fraction_grass_source parameter must be set if et_fraction_type==\'grass\''
+            )
+        self.et_fraction_grass_source = et_fraction_grass_source
+        # CGM - Should the supported source values be checked here instead of in model.py?
+        # if et_fraction_grass_source not in et_fraction_grass_sources:
+        #     raise ValueError('unsupported et_fraction_grass_source')
 
         self.reflectance_type = reflectance_type
         if reflectance_type not in ['SR', 'TOA']:
@@ -333,50 +343,16 @@ class Image:
 
         et_fraction = model.et_fraction(lst=self.lst, tmax=tmax, tcorr=self.tcorr, dt=dt)
 
-        # TODO: Add support for setting the conversion source dataset
-        # TODO: Interpolate "instantaneous" ETo and ETr?
-        # TODO: Move openet.refetgee import to top?
-        # TODO: Check if etr/eto is right (I think it is)
-        if self.et_fraction_type.lower() == 'grass':
-            import openet.refetgee
-            nldas_coll = (
-                ee.ImageCollection('NASA/NLDAS/FORA0125_H002')
-                .select(['temperature', 'specific_humidity', 'shortwave_radiation', 'wind_u', 'wind_v'])
-            )
-
-            # Interpolating hourly NLDAS to the Landsat scene time
-            # CGM - The 2 hour window is useful in case an image is missing
-            #   I think EEMETRIC is using a 4 hour window
-            # CGM - Need to check if the NLDAS images are instantaneous
-            #   or some sort of average of the previous or next hour
-            time_start = ee.Number(self._time_start)
-            prev_img = ee.Image(
-                nldas_coll
-                .filterDate(time_start.subtract(2 * 60 * 60 * 1000), time_start)
-                .limit(1, 'system:time_start', False)
-                .first()
-            )
-            next_img = ee.Image(
-                nldas_coll.filterDate(time_start, time_start.add(2 * 60 * 60 * 1000)).first()
-            )
-            prev_time = ee.Number(prev_img.get('system:time_start'))
-            next_time = ee.Number(next_img.get('system:time_start'))
-            time_ratio = time_start.subtract(prev_time).divide(next_time.subtract(prev_time))
-            nldas_img = (
-                next_img.subtract(prev_img).multiply(time_ratio).add(prev_img)
-                .set({'system:time_start': self._time_start})
-            )
-
-            # # DEADBEEF - Select NLDAS image before the Landsat scene time
-            # nldas_img = ee.Image(nldas_coll
-            #     .filterDate(self._date.advance(-1, 'hour'), self._date)
-            #     .first())
-
-            et_fraction = (
-                et_fraction
-                .multiply(openet.refetgee.Hourly.nldas(nldas_img).etr)
-                .divide(openet.refetgee.Hourly.nldas(nldas_img).eto)
-            )
+        # Convert the ET fraction to a grass reference fraction
+        if self.et_fraction_type.lower() == 'grass' and self.et_fraction_grass_source:
+            if utils.is_number(self.et_fraction_grass_source):
+                et_fraction = et_fraction.multiply(self.et_fraction_grass_source)
+            else:
+                et_fraction = model.etf_grass_type_adjust(
+                    etf=et_fraction,
+                    src_coll_id=self.et_fraction_grass_source,
+                    time_start=self._time_start
+                )
 
         return et_fraction.set(self._properties)\
             .set({

--- a/openet/ssebop/tests/test_c_image.py
+++ b/openet/ssebop/tests/test_c_image.py
@@ -67,25 +67,26 @@ def default_image(lst=305, ndvi=0.8, qa_water=0):
 
 # Setting et_reference_source and et_reference_band on the default image to
 #   simplify testing but these do not have defaults in the Image class init
-def default_image_args(lst=305, ndvi=0.85,
-                       # et_reference_source='IDAHO_EPSCOR/GRIDMET',
-                       et_reference_source=9.5730,
-                       et_reference_band='etr',
-                       et_reference_factor=1,
-                       et_reference_resample='nearest',
-                       et_reference_date_type=None,
-                       dt_source=18,
-                       tcorr_source=0.9744,
-                       tmax_source=310.15,
-                       elev_source=67,
-                       elr_flag=False,
-                       et_fraction_type='alfalfa',
-                       et_fraction_grass_source=None,
-                       reflectance_type='SR',
-                       dt_resample='nearest',
-                       tmax_resample='nearest',
-                       tcorr_resample='nearest',
-                       ):
+def default_image_args(
+        lst=305, ndvi=0.85,
+        # et_reference_source='IDAHO_EPSCOR/GRIDMET',
+        et_reference_source=9.5730,
+        et_reference_band='etr',
+        et_reference_factor=1,
+        et_reference_resample='nearest',
+        et_reference_date_type=None,
+        dt_source=18,
+        tcorr_source=0.9744,
+        tmax_source=310.15,
+        elev_source=67,
+        elr_flag=False,
+        et_fraction_type='alfalfa',
+        et_fraction_grass_source=None,
+        reflectance_type='SR',
+        dt_resample='nearest',
+        tmax_resample='nearest',
+        tcorr_resample='nearest',
+        ):
     return {
         'image': default_image(lst=lst, ndvi=ndvi),
         'et_reference_source': et_reference_source,
@@ -107,25 +108,26 @@ def default_image_args(lst=305, ndvi=0.85,
     }
 
 
-def default_image_obj(lst=305, ndvi=0.85,
-                      # et_reference_source='IDAHO_EPSCOR/GRIDMET',
-                      et_reference_source=9.5730,
-                      et_reference_band='etr',
-                      et_reference_factor=1,
-                      et_reference_resample='nearest',
-                      et_reference_date_type=None,
-                      dt_source=18,
-                      tcorr_source=0.9744,
-                      tmax_source=310.15,
-                      elev_source=67,
-                      elr_flag=False,
-                      et_fraction_type='alfalfa',
-                      et_fraction_grass_source=None,
-                      reflectance_type='SR',
-                      dt_resample='nearest',
-                      tmax_resample='nearest',
-                      tcorr_resample='nearest',
-                      ):
+def default_image_obj(
+        lst=305, ndvi=0.85,
+        # et_reference_source='IDAHO_EPSCOR/GRIDMET',
+        et_reference_source=9.5730,
+        et_reference_band='etr',
+        et_reference_factor=1,
+        et_reference_resample='nearest',
+        et_reference_date_type=None,
+        dt_source=18,
+        tcorr_source=0.9744,
+        tmax_source=310.15,
+        elev_source=67,
+        elr_flag=False,
+        et_fraction_type='alfalfa',
+        et_fraction_grass_source=None,
+        reflectance_type='SR',
+        dt_resample='nearest',
+        tmax_resample='nearest',
+        tcorr_resample='nearest',
+        ):
     return ssebop.Image(**default_image_args(
         lst=lst, ndvi=ndvi,
         et_reference_source=et_reference_source,
@@ -1506,20 +1508,25 @@ def test_Image_from_landsat_c2_sr_et_fraction():
     assert output['properties']['system:index'] == image_id.split('/')[-1]
 
 
-def test_Image_et_fraction_type_grass_source_not_set():
-    """Raise an exception if fraction type is grass but source is not set"""
-    with pytest.raises(ValueError):
-        utils.getinfo(default_image_obj(et_fraction_type='grass').et_fraction)
+# # Testing for the source not being set will be needed in a future version
+# #   when NLDAS is not set as the default source
+# def test_Image_et_fraction_type_grass_source_not_set():
+#     """Raise an exception if fraction type is grass but source is not set"""
+#     with pytest.raises(ValueError):
+#         utils.getinfo(default_image_obj(et_fraction_type='grass').et_fraction)
+#
+#
+# # Testing for the source not being set will be needed in a future version
+# #   when NLDAS is not set as the default source
+# def test_Image_et_fraction_type_grass_source_empty():
+#     """Raise an exception if fraction type is grass but source is not set"""
+#     with pytest.raises(ValueError):
+#         utils.getinfo(default_image_obj(
+#             et_fraction_type='grass', et_fraction_grass_source='').et_fraction)
 
 
-def test_Image_et_fraction_type_grass_source_empty():
-    """Raise an exception if fraction type is grass but source is not set"""
-    with pytest.raises(ValueError):
-        utils.getinfo(default_image_obj(
-            et_fraction_type='grass', et_fraction_grass_source='').et_fraction)
-
-
-# CGM - Checking if the source is "supported" is currently handled in the model.py function
+# # Checking if the source is "supported" is currently handled in the model.py function
+# #   and is probably redundant here, but leaving commented out code for now
 # def test_Image_et_fraction_type_grass_source_exception():
 #     """Raise an exception if fraction type is grass but source is not supported"""
 #     with pytest.raises(ValueError):

--- a/openet/ssebop/tests/test_c_image.py
+++ b/openet/ssebop/tests/test_c_image.py
@@ -80,6 +80,7 @@ def default_image_args(lst=305, ndvi=0.85,
                        elev_source=67,
                        elr_flag=False,
                        et_fraction_type='alfalfa',
+                       et_fraction_grass_source=None,
                        reflectance_type='SR',
                        dt_resample='nearest',
                        tmax_resample='nearest',
@@ -98,6 +99,7 @@ def default_image_args(lst=305, ndvi=0.85,
         'elev_source': elev_source,
         'elr_flag': elr_flag,
         'et_fraction_type': et_fraction_type,
+        'et_fraction_grass_source': et_fraction_grass_source,
         'reflectance_type': reflectance_type,
         'dt_resample': dt_resample,
         'tmax_resample': tmax_resample,
@@ -118,6 +120,7 @@ def default_image_obj(lst=305, ndvi=0.85,
                       elev_source=67,
                       elr_flag=False,
                       et_fraction_type='alfalfa',
+                      et_fraction_grass_source=None,
                       reflectance_type='SR',
                       dt_resample='nearest',
                       tmax_resample='nearest',
@@ -136,6 +139,7 @@ def default_image_obj(lst=305, ndvi=0.85,
         elev_source=elev_source,
         elr_flag=elr_flag,
         et_fraction_type=et_fraction_type,
+        et_fraction_grass_source=et_fraction_grass_source,
         reflectance_type=reflectance_type,
         dt_resample=dt_resample,
         tmax_resample=tmax_resample,
@@ -157,6 +161,8 @@ def test_Image_init_default_parameters():
     assert m._dt_max == 25
     assert m._elev_source is None
     assert m._elr_flag is False
+    assert m.et_fraction_type == 'alfalfa'
+    assert m.et_fraction_grass_source is None
     assert m.reflectance_type == 'SR'
     assert m._dt_resample == 'bilinear'
     assert m._tmax_resample == 'bilinear'
@@ -625,14 +631,15 @@ def test_Image_from_landsat_c2_sr_scaling():
     """Test if Landsat SR images images are being scaled"""
     sr_img = ee.Image('LANDSAT/LC08/C02/T1_L2/LC08_044033_20170716')
     # CGM - These reflectances should correspond to 0.1 for RED and 0.2 for NIR
-    input_img = ee.Image.constant([10909, 10909, 10909, 14545, 10909, 10909,
-                                   44177.6, 21824, 0]) \
+    input_img = (
+        ee.Image.constant([10909, 10909, 10909, 14545, 10909, 10909, 44177.6, 21824, 0])
         .rename(['SR_B2', 'SR_B3', 'SR_B4', 'SR_B5', 'SR_B6', 'SR_B7',
-                 'ST_B10', 'QA_PIXEL', 'QA_RADSAT']) \
+                 'ST_B10', 'QA_PIXEL', 'QA_RADSAT'])
         .set({'SPACECRAFT_ID': ee.String(sr_img.get('SPACECRAFT_ID')),
               'system:id': ee.String(sr_img.get('system:id')),
               'system:index': ee.String(sr_img.get('system:index')),
               'system:time_start': ee.Number(sr_img.get('system:time_start'))})
+    )
 
     output = utils.constant_image_value(ssebop.Image.from_landsat_c2_sr(input_img).ndvi)
     assert abs(output['ndvi'] - 0.333) <= 0.01
@@ -700,8 +707,7 @@ def test_Image_from_method_kwargs():
 
 
 # CGM - Test tcorr_image since it is called by tcorr_stats
-def test_Image_tcorr_image_values(lst=300, ndvi=0.85, tmax=306, expected=0.9804,
-                                  tol=0.0001):
+def test_Image_tcorr_image_values(lst=300, ndvi=0.85, tmax=306, expected=0.9804, tol=0.0001):
     output_img = default_image_obj(lst=lst, ndvi=ndvi, tmax_source=tmax).tcorr_image
     output = utils.point_image_value(output_img, TEST_POINT)
     assert abs(output['tcorr'] - expected) <= tol
@@ -1500,27 +1506,47 @@ def test_Image_from_landsat_c2_sr_et_fraction():
     assert output['properties']['system:index'] == image_id.split('/')[-1]
 
 
+def test_Image_et_fraction_type_grass_source_not_set():
+    """Raise an exception if fraction type is grass but source is not set"""
+    with pytest.raises(ValueError):
+        utils.getinfo(default_image_obj(et_fraction_type='grass').et_fraction)
+
+
+def test_Image_et_fraction_type_grass_source_empty():
+    """Raise an exception if fraction type is grass but source is not set"""
+    with pytest.raises(ValueError):
+        utils.getinfo(default_image_obj(
+            et_fraction_type='grass', et_fraction_grass_source='').et_fraction)
+
+
+# CGM - Checking if the source is "supported" is currently handled in the model.py function
+# def test_Image_et_fraction_type_grass_source_exception():
+#     """Raise an exception if fraction type is grass but source is not supported"""
+#     with pytest.raises(ValueError):
+#         utils.getinfo(default_image_obj(
+#             et_fraction_type='grass', et_fraction_grass_source='deadbeef').et_fraction)
+
+
 @pytest.mark.parametrize(
-    'et_fraction_type, expected',
+    'et_fraction_type, etf_grass_source, expected',
     [
-        # ['alfalfa', 0.88],
-        ['grass', 0.88 * 1.24],
-        # ['Grass', 0.88 * 0.5],
+        ['alfalfa', None, 0.88],
+        ['grass', 'NASA/NLDAS/FORA0125_H002', 0.88 * 1.24],
+        # Check that mixed case fraction types are supported
+        ['Grass', 'NASA/NLDAS/FORA0125_H002', 0.88 * 1.24],
+        # Check that number sources are supported
+        ['grass', 1.24, 0.88 * 1.24],
+        # Currently checking all other supported sources in model.py test
+        # ['grass', 'ECMWF/ERA5_LAND/HOURLY', 0.88 * 1.15],
     ]
 )
-def test_Image_et_fraction_type(et_fraction_type, expected, tol=0.0001):
+def test_Image_et_fraction_type(et_fraction_type, etf_grass_source, expected, tol=0.01):
     output_img = default_image_obj(
-        dt_source=10, elev_source=50,
-        tcorr_source=0.98, tmax_source=310,
-        et_fraction_type=et_fraction_type).et_fraction
+        dt_source=10, elev_source=50, tcorr_source=0.98, tmax_source=310,
+        et_fraction_type=et_fraction_type,
+        et_fraction_grass_source=etf_grass_source).et_fraction
     output = utils.point_image_value(ee.Image(output_img), TEST_POINT)
     assert abs(output['et_fraction'] - expected) <= tol
-    # assert output['bands'][0]['id'] == 'et_fraction'
-
-
-def test_Image_et_fraction_type_exception():
-    with pytest.raises(ValueError):
-        utils.getinfo(default_image_obj(et_fraction_type='deadbeef').et_fraction)
 
 
 def test_Image_et_reference_properties():

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "openet-ssebop"
-version = "0.3.1"
+version = "0.3.2"
 authors = [
   { name = "Gabe Parrish", email = "gparrish@contractor.usgs.gov" },
   { name = "Mac Friedrichs", email = "mfriedrichs@contractor.usgs.gov" },
@@ -23,7 +23,7 @@ classifiers = [
 dependencies = [
     "earthengine-api>=0.1.364",
     "openet-core>=0.1.1",
-    "openet-refet-gee>=0.2.0",
+    "openet-refet-gee>=0.6.2",
     "python-dateutil",
     "importlib-metadata; python_version <= '3.7'",
 ]


### PR DESCRIPTION
This will allow the user to set the data source for making the alfalfa to grass reference adjustment of the ET fraction.

There is only support for using the NLDAS and ERA5-Land hourly collections in GEE (`NASA/NLDAS/FORA0125_H002` and `ECMWF/ERA5_LAND/HOURLY`), but support for other sources like daily meteorology or reference ET collections may be added in a future version.

The code will currently default to using NLDAS if the parameter is not set, but this will be changed in a future version (0.4.0?) so that the `et_fraction_grass_source` parameter must be set if `et_fraction_type=='grass'`.

