### PR TITLE
v0.4.2

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,20 +1,23 @@
-name: build
+name: Run Tests
 
 on:
   push:
-    branches: [ main ]
+    branches: [ "main" ]
   pull_request:
-    branches: [ main ]
+    branches: [ "main" ]
+
+permissions:
+  contents: read
 
 jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v1
-    - name: Set up Python 3.9
-      uses: actions/setup-python@v1
+    - uses: actions/checkout@v3
+    - name: Set up Python 3.10
+      uses: actions/setup-python@v3
       with:
-        python-version: 3.9
+        python-version: "3.10"
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip

--- a/openet/ssebop/__init__.py
+++ b/openet/ssebop/__init__.py
@@ -1,14 +1,10 @@
-# try:
-#     from importlib import metadata
-# except ImportError:  # for Python<3.8
-#     import importlib_metadata as metadata
-
 from .image import Image
 from .collection import Collection
 from . import interpolate
 
 MODEL_NAME = 'SSEBOP'
 
+# from importlib import metadata
 # # __version__ = metadata.version(__package__ or __name__)
 # __version__ = metadata.version(__package__.replace('.', '-') or __name__.replace('.', '-'))
 # # __version__ = metadata.version('openet-ssebop')

--- a/openet/ssebop/image.py
+++ b/openet/ssebop/image.py
@@ -317,7 +317,7 @@ class Image:
                 et_fraction = model.etf_grass_type_adjust(
                     etf=et_fraction,
                     src_coll_id=self.et_fraction_grass_source,
-                    time_start=self._time_start
+                    time_start=self._time_start,
                 )
 
         return et_fraction.set(self._properties)\

--- a/openet/ssebop/image.py
+++ b/openet/ssebop/image.py
@@ -616,12 +616,12 @@ class Image:
 
     @classmethod
     def from_landsat_c2_sr(cls, sr_image, cloudmask_args={}, **kwargs):
-        """Returns a SSEBop Image instance from a Landsat Collection 2 SR image
+        """Returns a SSEBop Image instance from a Landsat C02 level 2 (SR) image
 
         Parameters
         ----------
         sr_image : ee.Image, str
-            A raw Landsat Collection 2 SR image or image ID.
+            A raw Landsat Collection 2 level 2 (SR) SR image or image ID.
         cloudmask_args : dict
             keyword arguments to pass through to cloud mask function
         kwargs : dict

--- a/openet/ssebop/image.py
+++ b/openet/ssebop/image.py
@@ -339,9 +339,11 @@ class Image:
             if (self.et_reference_date_type is None or
                     self.et_reference_date_type.lower() == 'daily'):
                 # Assume the collection is daily with valid system:time_start values
-                et_reference_coll = ee.ImageCollection(self.et_reference_source)\
-                    .filterDate(self._start_date, self._end_date)\
+                et_reference_coll = (
+                    ee.ImageCollection(self.et_reference_source)
+                    .filterDate(self._start_date, self._end_date)
                     .select([self.et_reference_band])
+                )
             elif self.et_reference_date_type.lower() == 'doy':
                 # Assume the image collection is a climatology with a "DOY" property
                 et_reference_coll = (
@@ -673,11 +675,11 @@ class Image:
         if 'snow_flag' not in cloudmask_args.keys():
             cloudmask_args['snow_flag'] = True
         if 'cloud_score_flag' not in cloudmask_args.keys():
-            cloudmask_args['cloud_score_flag'] = True
+            cloudmask_args['cloud_score_flag'] = False
         if 'cloud_score_pct' not in cloudmask_args.keys():
             cloudmask_args['cloud_score_pct'] = 100
         if 'filter_flag' not in cloudmask_args.keys():
-            cloudmask_args['filter_flag'] = True
+            cloudmask_args['filter_flag'] = False
         # Will need to add the QA_RADSAT band above if this is set to True
         if 'saturated_flag' not in cloudmask_args.keys():
             cloudmask_args['saturated_flag'] = False

--- a/openet/ssebop/tests/conftest.py
+++ b/openet/ssebop/tests/conftest.py
@@ -5,32 +5,20 @@ import os
 import ee
 import pytest
 
-logging.getLogger('earthengine-api').setLevel(logging.INFO)
-logging.getLogger('googleapiclient').setLevel(logging.INFO)
-logging.getLogger('requests').setLevel(logging.INFO)
-logging.getLogger('urllib3').setLevel(logging.INFO)
 
-
-def pytest_configure():
-    # Called before tests are collected
-    # https://docs.pytest.org/en/latest/reference.html#_pytest.hookspec.pytest_sessionstart
+@pytest.fixture(scope="session", autouse=True)
+def test_init():
     logging.basicConfig(level=logging.DEBUG, format='%(message)s')
     logging.getLogger('googleapiclient').setLevel(logging.ERROR)
     logging.debug('Test Setup')
 
-    # On Travis-CI authenticate using private key environment variable
+    # For GitHub Actions authenticate using private key environment variable
     if 'EE_PRIVATE_KEY_B64' in os.environ:
         print('Writing privatekey.json from environmental variable ...')
         content = base64.b64decode(os.environ['EE_PRIVATE_KEY_B64']).decode('ascii')
-        GEE_KEY_FILE = 'privatekey.json'
-        with open(GEE_KEY_FILE, 'w') as f:
+        EE_KEY_FILE = 'privatekey.json'
+        with open(EE_KEY_FILE, 'w') as f:
             f.write(content)
-        ee.Initialize(ee.ServiceAccountCredentials('', key_file=GEE_KEY_FILE))
+        ee.Initialize(ee.ServiceAccountCredentials('', key_file=EE_KEY_FILE))
     else:
         ee.Initialize()
-
-
-@pytest.fixture(scope="session", autouse=True)
-def test_init():
-    # Make a simple EE request
-    ee.Number(1).getInfo()

--- a/openet/ssebop/tests/test_a_utils.py
+++ b/openet/ssebop/tests/test_a_utils.py
@@ -21,24 +21,39 @@ def test_getinfo_exception():
 #     assert utils.getinfo(ee.Number('deadbeef')) is None
 
 
-def test_constant_image_value(tol=0.000001):
-    expected = 10.123456789
-    input_img = ee.Image.constant(expected)
-    output = utils.constant_image_value(input_img)
+def test_constant_image_value(expected=10.123456789, tol=0.000001):
+    output = utils.constant_image_value(ee.Image.constant(expected))
     assert abs(output['constant'] - expected) <= tol
 
 
-def test_point_image_value(tol=0.001):
-    expected = 2364.351
-    output = utils.point_image_value(ee.Image('USGS/NED'), [-106.03249, 37.17777])
-    assert abs(output['elevation'] - expected) <= tol
+@pytest.mark.parametrize(
+    'image_id, xy, scale, expected, tol',
+    [
+        ['USGS/NED', [-106.03249, 37.17777], 10, 2364.351, 0.001],
+        ['USGS/NED', [-106.03249, 37.17777], 1, 2364.351, 0.001],
+    ]
+)
+def test_point_image_value(image_id, xy, scale, expected, tol):
+    output = utils.point_image_value(ee.Image(image_id).rename('output'), xy)
+    assert abs(output['output'] - expected) <= tol
 
 
-def test_point_coll_value(tol=0.001):
-    expected = 2364.351
-    output = utils.point_coll_value(
-        ee.ImageCollection([ee.Image('USGS/NED')]), [-106.03249, 37.17777])
-    assert abs(output['elevation']['2012-04-04'] - expected) <= tol
+@pytest.mark.parametrize(
+    'image_id, image_date, xy, scale, expected, tol',
+    [
+        # CGM - This test stopped working for a scale of 1 and returns a different
+        #   value for a scale of 10 than the point_image_value() function above.
+        # This function uses getRegion() instead of a reduceRegion() call,
+        #   so there might have been some sort of change in getRegion().
+        ['USGS/NED', '2012-04-04', [-106.03249, 37.17777], 10, 2364.286, 0.001],
+        # CGM - The default scale of 1 now returns None/Null for some reason
+        # ['USGS/NED', '2012-04-04', [-106.03249, 37.17777], 1, 2364.351, 0.001],
+    ]
+)
+def test_point_coll_value(image_id, image_date, xy, scale, expected, tol):
+    input_img = ee.Image(image_id).rename(['output'])
+    output = utils.point_coll_value(ee.ImageCollection([input_img]), xy, scale)
+    assert abs(output['output'][image_date] - expected) <= tol
 
 
 def test_c_to_k(c=20, k=293.15, tol=0.000001):
@@ -51,12 +66,10 @@ def test_c_to_k(c=20, k=293.15, tol=0.000001):
     [
         ['2015-07-13T18:33:39', 1436745600000],
         ['2015-07-13T00:00:00', 1436745600000],
-
     ]
 )
 def test_date_to_time_0utc(input, expected):
-    input_img = ee.Date(input)
-    assert utils.getinfo(utils.date_to_time_0utc(input_img)) == expected
+    assert utils.getinfo(utils.date_to_time_0utc(ee.Date(input))) == expected
 
 
 @pytest.mark.parametrize(

--- a/openet/ssebop/tests/test_c_image.py
+++ b/openet/ssebop/tests/test_c_image.py
@@ -430,13 +430,14 @@ def test_Image_from_landsat_c2_sr_scaling():
               'system:time_start': ee.Number(sr_img.get('system:time_start'))})
     )
 
-    # LST correction does not work with a constant image
-    output = utils.constant_image_value(
-        ssebop.Image.from_landsat_c2_sr(input_img, c2_lst_correct=False).ndvi)
+    # LST correction and cloud score masking do not work with a constant image
+    #   and must be explicitly set to False
+    output = utils.constant_image_value(ssebop.Image.from_landsat_c2_sr(
+        input_img, c2_lst_correct=False, cloudmask_args={'cloud_score_flag': False}).ndvi)
     assert abs(output['ndvi'] - 0.333) <= 0.01
 
-    output = utils.constant_image_value(
-        ssebop.Image.from_landsat_c2_sr(input_img, c2_lst_correct=False).lst)
+    output = utils.constant_image_value(ssebop.Image.from_landsat_c2_sr(
+        input_img, c2_lst_correct=False, cloudmask_args={'cloud_score_flag': False}).lst)
     assert abs(output['lst'] - 300) <= 0.1
 
 
@@ -445,6 +446,14 @@ def test_Image_from_landsat_c2_sr_cloud_mask_args():
     image_id = 'LANDSAT/LC08/C02/T1_L2/LC08_044033_20170716'
     output = ssebop.Image.from_landsat_c2_sr(
         image_id, cloudmask_args={'snow_flag': True, 'cirrus_flag': True})
+    assert type(output) == type(default_image_obj())
+
+
+def test_Image_from_landsat_c2_sr_cloud_score_mask_arg():
+    """Test if the cloud_score_flag parameter can be set in cloudmask_args"""
+    image_id = 'LANDSAT/LC08/C02/T1_L2/LC08_044033_20170716'
+    output = ssebop.Image.from_landsat_c2_sr(
+        image_id, cloudmask_args={'cloud_score_flag': True})
     assert type(output) == type(default_image_obj())
 
 

--- a/openet/ssebop/tests/test_c_image.py
+++ b/openet/ssebop/tests/test_c_image.py
@@ -412,7 +412,7 @@ def test_Image_from_landsat_c2_sr_image():
 def test_Image_from_landsat_c2_sr_exception():
     """Test instantiating the class for an invalid image ID"""
     with pytest.raises(Exception):
-        # Intentionally using .getInfo()
+        # Intentionally using .getInfo() instead of utils.getinfo()
         ssebop.Image.from_landsat_c2_sr(ee.Image('FOO')).ndvi.getInfo()
 
 
@@ -433,11 +433,13 @@ def test_Image_from_landsat_c2_sr_scaling():
     # LST correction and cloud score masking do not work with a constant image
     #   and must be explicitly set to False
     output = utils.constant_image_value(ssebop.Image.from_landsat_c2_sr(
-        input_img, c2_lst_correct=False, cloudmask_args={'cloud_score_flag': False}).ndvi)
+        input_img, c2_lst_correct=False,
+        cloudmask_args={'cloud_score_flag': False, 'filter_flag': False}).ndvi)
     assert abs(output['ndvi'] - 0.333) <= 0.01
 
     output = utils.constant_image_value(ssebop.Image.from_landsat_c2_sr(
-        input_img, c2_lst_correct=False, cloudmask_args={'cloud_score_flag': False}).lst)
+        input_img, c2_lst_correct=False,
+        cloudmask_args={'cloud_score_flag': False, 'filter_flag': False}).lst)
     assert abs(output['lst'] - 300) <= 0.1
 
 
@@ -483,6 +485,7 @@ def test_Image_from_landsat_c2_sr_c2_lst_correct_fill():
     'image_id',
     [
         'LANDSAT/LC08/C02/T1_L2/LC08_044033_20170716',
+        'LANDSAT/LC09/C02/T1_L2/LC09_044033_20220127',
     ]
 )
 def test_Image_from_image_id(image_id):
@@ -548,9 +551,10 @@ def test_Image_tcorr_stats_constant(tcorr=0.993548387, count=40564857, tol=0.000
 @pytest.mark.parametrize(
     'image_id, tmax_source, expected',
     [
-        ['LANDSAT/LC08/C02/T1_L2/LC08_042035_20150713',
-         'projects/usgs-ssebop/tmax/daymet_v3_median_1980_2018',
-         {'tcorr_value': 0.9757137560969104, 'tcorr_count': 221975}],
+        # DEADBEEF
+        # ['LANDSAT/LC08/C02/T1_L2/LC08_042035_20150713',
+        #  'projects/usgs-ssebop/tmax/daymet_v3_median_1980_2018',
+        #  {'tcorr_value': 0.9757137560969104, 'tcorr_count': 221975}],
         # projects/usgs-ssebop/tmax/daymet_v4_mean_1981_2010
         ['LANDSAT/LC08/C02/T1_L2/LC08_042035_20150713',
          'projects/usgs-ssebop/tmax/daymet_v4_mean_1981_2010',
@@ -726,11 +730,16 @@ def test_Image_et_reference_properties():
     [
         ['IDAHO_EPSCOR/GRIDMET', 'etr', 1, TEST_POINT, 9.5730],
         ['IDAHO_EPSCOR/GRIDMET', 'etr', 0.85, TEST_POINT, 9.5730 * 0.85],
-        ['projects/earthengine-legacy/assets/projects/climate-engine/cimis/daily',
-         'ETr_ASCE', 1, TEST_POINT, 10.0220],
+        ['projects/openet/assets/reference_et/california/cimis/daily/v1',
+         'etr', 1, TEST_POINT, 10.0760],
+        ['projects/openet/reference_et/california/cimis/daily/v1',
+         'etr', 1, TEST_POINT, 10.0760],
+        # DEADBEEF
+        # ['projects/earthengine-legacy/assets/projects/climate-engine/cimis/daily',
+        #  'ETr_ASCE', 1, TEST_POINT, 10.0220],
         # CGM - Why are these not the same?
-        ['projects/earthengine-legacy/assets/projects/openet/reference_et/cimis/daily',
-         'etr_asce', 1, TEST_POINT, 10.0760],
+        # ['projects/earthengine-legacy/assets/projects/openet/reference_et/cimis/daily',
+        #  'etr_asce', 1, TEST_POINT, 10.0760],
         [10, 'FOO', 1, TEST_POINT, 10.0],
         [10, 'FOO', 0.85, TEST_POINT, 8.5],
     ]

--- a/openet/ssebop/tests/test_d_collection.py
+++ b/openet/ssebop/tests/test_d_collection.py
@@ -35,7 +35,7 @@ default_coll_args = {
     # 'et_reference_date_type': 'daily',
     'model_args': {
         'tcorr_source': 0.99,
-        'cloudmask_args': {'cloud_score_flag': False, 'filter_flag': False}
+        'cloudmask_args': {'cloud_score_flag': False, 'filter_flag': False},
     },
     # 'model_args': {},
     'filter_args': {},

--- a/openet/ssebop/tests/test_d_collection.py
+++ b/openet/ssebop/tests/test_d_collection.py
@@ -33,7 +33,10 @@ default_coll_args = {
     'et_reference_resample': 'nearest',
     'et_reference_date_type': None,
     # 'et_reference_date_type': 'daily',
-    'model_args': {'tcorr_source': 0.99},
+    'model_args': {
+        'tcorr_source': 0.99,
+        'cloudmask_args': {'cloud_score_flag': False, 'filter_flag': False}
+    },
     # 'model_args': {},
     'filter_args': {},
 }
@@ -70,7 +73,7 @@ def test_Collection_init_default_parameters():
     assert m.et_reference_resample is None
     assert m.et_reference_date_type is None
     assert m.cloud_cover_max == 70
-    assert m.model_args == {'tcorr_source': 0.99}
+    # assert m.model_args == {'tcorr_source': 0.99}
     assert m.filter_args == {}
     assert set(m._interp_vars) == {'ndvi', 'et_fraction'}
 
@@ -489,9 +492,10 @@ def test_Collection_interpolate_et_reference_date_type_exception():
 def test_Collection_interpolate_et_reference_params_kwargs():
     """Test setting et_reference parameters in the Collection init args"""
     output = utils.getinfo(default_coll_obj(
+        # collections=['LANDSAT/LC08/C02/T1_L2'],
         et_reference_source='IDAHO_EPSCOR/GRIDMET', et_reference_band='etr',
         et_reference_factor=0.5, et_reference_resample='bilinear',
-        model_args={}).interpolate())
+        model_args={}).interpolate(use_joins=True))
     assert {y['id'] for x in output['features'] for y in x['bands']} == VARIABLES
     assert output['features'][0]['properties']['et_reference_factor'] == 0.5
     assert output['features'][0]['properties']['et_reference_resample'] == 'bilinear'
@@ -504,7 +508,7 @@ def test_Collection_interpolate_et_reference_params_model_args():
         et_reference_factor=None, et_reference_resample=None,
         model_args={'et_reference_source': 'IDAHO_EPSCOR/GRIDMET',
                     'et_reference_band': 'etr', 'et_reference_factor': 0.5,
-                    'et_reference_resample': 'bilinear'}).interpolate())
+                    'et_reference_resample': 'bilinear'}).interpolate(use_joins=True))
     assert {y['id'] for x in output['features'] for y in x['bands']} == VARIABLES
     assert output['features'][0]['properties']['et_reference_factor'] == 0.5
     assert output['features'][0]['properties']['et_reference_resample'] == 'bilinear'
@@ -518,7 +522,7 @@ def test_Collection_interpolate_et_reference_params_interpolate_args():
     output = utils.getinfo(default_coll_obj(
         et_reference_source=None, et_reference_band=None,
         et_reference_factor=None, et_reference_resample=None,
-        model_args={}).interpolate(**et_reference_args))
+        model_args={}).interpolate(use_joins=True, **et_reference_args))
     assert {y['id'] for x in output['features'] for y in x['bands']} == VARIABLES
     assert output['features'][0]['properties']['et_reference_factor'] == 0.5
     assert output['features'][0]['properties']['et_reference_resample'] == 'bilinear'

--- a/openet/ssebop/tests/test_d_collection.py
+++ b/openet/ssebop/tests/test_d_collection.py
@@ -8,7 +8,6 @@ import openet.ssebop.utils as utils
 # TODO: import utils from openet.core
 # import openet.core.utils as utils
 
-
 C02_COLLECTIONS = ['LANDSAT/LC08/C02/T1_L2', 'LANDSAT/LE07/C02/T1_L2']
 # Image LE07_044033_20170724 is not (yet?) in LANDSAT/LE07/C02/T1_L2
 C02_SCENE_ID_LIST = ['LC08_044033_20170716', 'LE07_044033_20170708']
@@ -20,30 +19,30 @@ VARIABLES = {'et', 'et_fraction', 'et_reference'}
 TEST_POINT = (-121.5265, 38.7399)
 
 
-default_coll_args = {
-    'collections': C02_COLLECTIONS,
-    'geometry': ee.Geometry.Point(SCENE_POINT),
-    'start_date': START_DATE,
-    'end_date': END_DATE,
-    'variables': list(VARIABLES),
-    'cloud_cover_max': 70,
-    'et_reference_source': 'IDAHO_EPSCOR/GRIDMET',
-    'et_reference_band': 'etr',
-    'et_reference_factor': 0.85,
-    'et_reference_resample': 'nearest',
-    'et_reference_date_type': None,
-    # 'et_reference_date_type': 'daily',
-    'model_args': {
-        'tcorr_source': 0.99,
-        'cloudmask_args': {'cloud_score_flag': False, 'filter_flag': False},
-    },
-    # 'model_args': {},
-    'filter_args': {},
-}
+def default_coll_args():
+    return  {
+        'collections': C02_COLLECTIONS,
+        'geometry': ee.Geometry.Point(SCENE_POINT),
+        'start_date': START_DATE,
+        'end_date': END_DATE,
+        'variables': list(VARIABLES),
+        'cloud_cover_max': 70,
+        'et_reference_source': 'IDAHO_EPSCOR/GRIDMET',
+        'et_reference_band': 'etr',
+        'et_reference_factor': 0.85,
+        'et_reference_resample': 'nearest',
+        'et_reference_date_type': None,
+        # 'et_reference_date_type': 'daily',
+        'model_args': {
+            'tcorr_source': 0.99,
+            'cloudmask_args': {'cloud_score_flag': False, 'filter_flag': False},
+        },
+        'filter_args': {},
+    }
 
 
 def default_coll_obj(**kwargs):
-    args = default_coll_args.copy()
+    args = default_coll_args().copy()
     args.update(kwargs)
     return ssebop.Collection(**args)
 
@@ -56,7 +55,7 @@ def parse_scene_id(output_info):
 
 def test_Collection_init_default_parameters():
     """Test if init sets default parameters"""
-    args = default_coll_args.copy()
+    args = default_coll_args().copy()
     # These values are being set above but have defaults that need to be checked
     del args['et_reference_source']
     del args['et_reference_band']
@@ -305,7 +304,8 @@ def test_Collection_build_filter_args_keyword():
     collections = ['LANDSAT/LC08/C02/T1_L2', 'LANDSAT/LE07/C02/T1_L2']
     wrs2_filter = [
         {'type': 'equals', 'leftField': 'WRS_PATH', 'rightValue': 44},
-        {'type': 'equals', 'leftField': 'WRS_ROW', 'rightValue': 33}]
+        {'type': 'equals', 'leftField': 'WRS_ROW', 'rightValue': 33},
+    ]
     coll_obj = default_coll_obj(
         collections=collections,
         geometry=ee.Geometry.Rectangle(-125, 35, -120, 40),

--- a/openet/ssebop/tests/test_d_interpolate.py
+++ b/openet/ssebop/tests/test_d_interpolate.py
@@ -35,8 +35,10 @@ def scene_coll(variables, et_fraction=0.4, et=5, ndvi=0.6):
 
     # Mask and time bands currently get added on to the scene collection
     #   and images are unscaled just before interpolating in the export tool
-    scene_img = ee.Image([img.add(et_fraction), img.add(et), img.add(ndvi), mask])\
+    scene_img = (
+        ee.Image([img.add(et_fraction), img.add(et), img.add(ndvi), mask])
         .rename(['et_fraction', 'et', 'ndvi', 'mask'])
+    )
     # CGM - I was having issues when I removed these backslashes,
     #   even though they shouldn't be needed
     scene_coll = ee.ImageCollection([

--- a/openet/ssebop/utils.py
+++ b/openet/ssebop/utils.py
@@ -14,7 +14,7 @@ def getinfo(ee_obj, n=4):
             output = ee_obj.getInfo()
         except ee.ee_exception.EEException as e:
             logging.info(f'    Resending query ({i}/{n})')
-            logging.debug(f'    {e}')
+            logging.info(f'    {e}')
             sleep(i ** 3)
             # if ('Earth Engine memory capacity exceeded' in str(e) or
             #         'Earth Engine capacity exceeded' in str(e)):

--- a/openet/ssebop/utils.py
+++ b/openet/ssebop/utils.py
@@ -33,7 +33,7 @@ def getinfo(ee_obj, n=4):
     return output
 
 
-# TODO: Import from common.utils
+# TODO: Import from openet.core.utils instead of defining here
 # Should these be test fixtures instead?
 # I'm not sure how to make them fixtures and allow input parameters
 def constant_image_value(image, crs='EPSG:32613', scale=1):
@@ -48,7 +48,11 @@ def constant_image_value(image, crs='EPSG:32613', scale=1):
 
 def point_image_value(image, xy, scale=1):
     """Extract the output value from a calculation at a point"""
-    rr_params = {'reducer': ee.Reducer.first(), 'geometry': ee.Geometry.Point(xy), 'scale': scale}
+    rr_params = {
+        'reducer': ee.Reducer.first(),
+        'geometry': ee.Geometry.Point(xy),
+        'scale': scale,
+    }
     return getinfo(ee.Image(image).reduceRegion(**rr_params))
 
 
@@ -67,6 +71,7 @@ def point_coll_value(coll, xy, scale=1):
         date = datetime.datetime.utcfromtimestamp(row[3] / 1000.0).strftime('%Y-%m-%d')
         for k, v in col_dict.items():
             info_dict[k][date] = row[col_dict[k]]
+
     return info_dict
     # return pd.DataFrame.from_dict(info_dict)
 
@@ -132,5 +137,5 @@ def valid_date(date_str, date_fmt='%Y-%m-%d'):
     try:
         datetime.datetime.strptime(date_str, date_fmt)
         return True
-    except Exception as e:
+    except:
         return False

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "openet-ssebop"
-version = "0.4.1"
+version = "0.4.2"
 authors = [
     { name = "Gabe Parrish", email = "gparrish@contractor.usgs.gov" },
     { name = "Mac Friedrichs", email = "mfriedrichs@contractor.usgs.gov" },
@@ -11,7 +11,7 @@ maintainers = [
 ]
 description = "Earth Engine implementation of the SSEBop model"
 readme = "README.rst"
-requires-python = ">=3.7"
+requires-python = ">=3.8"
 keywords = ["SSEBop", "OpenET", "Earth Engine", "Evapotranspiration", "Landsat"]
 license = { file = "LICENSE.txt" }
 # license = {text = "Apache-2.0"}
@@ -21,11 +21,10 @@ classifiers = [
     "Operating System :: OS Independent",
 ]
 dependencies = [
-    "earthengine-api>=0.1.364",
-    "openet-core>=0.2.0",
-    "openet-refet-gee>=0.6.2",
+    "earthengine-api >= 0.1.364",
+    "openet-core >= 0.4.0",
+    "openet-refet-gee >= 0.6.2",
     "python-dateutil",
-    "importlib-metadata; python_version <= '3.7'",
 ]
 
 [project.urls]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,7 @@ maintainers = [
 description = "Earth Engine implementation of the SSEBop model"
 readme = "README.rst"
 requires-python = ">=3.7"
-keywords = ["SSEBop", "OpenET", "Earth Engine", "evapotranspiration"]
+keywords = ["SSEBop", "OpenET", "Earth Engine", "Evapotranspiration", "Landsat"]
 license = { file = "LICENSE.txt" }
 # license = {text = "Apache-2.0"}
 classifiers = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,18 +2,18 @@
 name = "openet-ssebop"
 version = "0.4.1"
 authors = [
-  { name = "Gabe Parrish", email = "gparrish@contractor.usgs.gov" },
-  { name = "Mac Friedrichs", email = "mfriedrichs@contractor.usgs.gov" },
-  { name = "Gabriel Senay", email = "senay@usgs.gov" },
+    { name = "Gabe Parrish", email = "gparrish@contractor.usgs.gov" },
+    { name = "Mac Friedrichs", email = "mfriedrichs@contractor.usgs.gov" },
+    { name = "Gabriel Senay", email = "senay@usgs.gov" },
 ]
-# maintainers = [
-#   { name = "Gabe Parrish", email = "gparrish@contractor.usgs.gov" }
-# ]
-description = "Earth Engine based SSEBop Model"
+maintainers = [
+    { name = "Charles Morton", email = "charles.morton@dri.edu" }
+]
+description = "Earth Engine implementation of the SSEBop model"
 readme = "README.rst"
 requires-python = ">=3.7"
 keywords = ["SSEBop", "OpenET", "Earth Engine", "evapotranspiration"]
-license = {file = "LICENSE.txt"}
+license = { file = "LICENSE.txt" }
 # license = {text = "Apache-2.0"}
 classifiers = [
     "Programming Language :: Python :: 3",
@@ -22,7 +22,7 @@ classifiers = [
 ]
 dependencies = [
     "earthengine-api>=0.1.364",
-    "openet-core>=0.1.3",
+    "openet-core>=0.2.0",
     "openet-refet-gee>=0.6.2",
     "python-dateutil",
     "importlib-metadata; python_version <= '3.7'",
@@ -40,9 +40,7 @@ requires = ["setuptools>=61.0"]
 build-backend = "setuptools.build_meta"
 
 [project.optional-dependencies]
-test = [
-    "pytest",
-]
+test = ["pytest"]
 
 [tool.setuptools.packages.find]
 # include = ["openet*"]


### PR DESCRIPTION
Originally was intending on adding cloud score masking support but ended up leaving flag default values to False.

Updated minimum Python to 3.8, bumped openet-core minimum version to 0.4.0 to get updated LST correction calculation, added bilinear resampling support to collection and interpolate to mirror approach in openet-core, and set use_joins default to True.  Lots of other code cleanup and formatting.