### PR TITLE
v0.4.2

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,4 +1,4 @@
-name: Run Tests
+name: Tests
 
 on:
   push:


### PR DESCRIPTION
Updated cloud masking to support QA_RADSAT and simple cloud score masking, but leaving defaults to False for now.

Added support for resampling hourly reference ET used for the alfalfa to grass conversions and set default to bilinear. 